### PR TITLE
CU-86azyk87x - Add field 'shipstation_store_id' to Spree::Store model…

### DIFF
--- a/lib/solidus_shipstation/api/batch_syncer.rb
+++ b/lib/solidus_shipstation/api/batch_syncer.rb
@@ -56,8 +56,8 @@ module SolidusShipstation
           shipstation_order_id: shipstation_order['orderId']
         }
 
-        store_id = shipstation_order.dig('advancedOptions', 'storeId')
-        sync_opts[:store_id] = store_id if store_id
+        shipstation_store_id = shipstation_order.dig('advancedOptions', 'storeId')
+        sync_opt[:shipstation_store_id] = store_id if shipstation_store_id
 
         shipment.update_columns(sync_opts)
 


### PR DESCRIPTION
…, add data migration to pre-populate it with correct values.. use these values instead of 'Spree::Store#id' in shipment serializers